### PR TITLE
[prettier-config] Add new rule to override jsxSingleQuote default behaviour 

### DIFF
--- a/.changeset/curly-jeans-laugh.md
+++ b/.changeset/curly-jeans-laugh.md
@@ -1,0 +1,5 @@
+---
+'@inigomarquinez/prettier-config': major
+---
+
+Set jsxSingleQuote option to true, overriding the default false value.

--- a/packages/prettier-config/README.md
+++ b/packages/prettier-config/README.md
@@ -10,6 +10,7 @@
 
 - [Installation](#📦-installation)
 - [Documentation](#📚-documentation)
+- [Custom configuration](#📚-custom-configuration)
 - [Contributing](#🧩-contributing)
 - [Changelog](#📝-changelog)
 - [License](#©️-license)
@@ -47,6 +48,18 @@ After installing it, a `.prettierrc` file will be created automatically in the p
 
 Read the [Prettier docs][prettier-docs-link] for more information. [Here][prettier-sharing-configurations-link] you can find specific information about sharing configurations.
 
+## 📏 Custom options
+
+The library customises the following options. All other options take their default value as defined [here][prettier-options-link].
+
+| Option | Custom value |
+| ------ | ------------ |
+| [arrowParens][prettier-option-arrow-parens-link] | `'avoid'` |
+| [experimentalTernaries][prettier-option-experimental-ternaries-link] | `true` |
+| [jsxSingleQuote][prettier-option-jsx-single-quote-link] | `true` |
+| [singleAttributePerLine][prettier-option-single-attribute-per-line-link] | `true` |
+| [singleQuote][prettier-option-single-quote-link] | `true` |
+
 ## 🧩 Contributing
 
 If you are interested in helping contribute, please open an [issue][issue-link] or [pull request][pull-request-link].
@@ -68,6 +81,12 @@ Distributed under the MIT License. See [LICENSE][license-link] for more informat
 [npm-link]: https://www.npmjs.com/package/@inigomarquinez/prettier-config
 [prettier-docs-link]: https://prettier.io
 [prettier-link]: https://github.com/prettier/prettier
+[prettier-option-arrow-parens-link]: https://prettier.io/docs/en/options.html#arrow-function-parentheses
+[prettier-option-experimental-ternaries-link]: https://prettier.io/docs/en/options.html#experimental-ternaries
+[prettier-option-jsx-single-quote-link]: https://prettier.io/docs/en/options.html#jsx-quotes
+[prettier-option-single-attribute-per-line-link]: https://prettier.io/docs/en/options.html#single-attribute-per-line
+[prettier-option-single-quote-link]: https://prettier.io/docs/en/options.html#quotes
+[prettier-options-link]: https://prettier.io/docs/en/options.html
 [prettier-sharing-configurations-link]: https://prettier.io/docs/en/configuration#sharing-configurations
 [pull-request-link]: https://github.com/inigomarquinez/base-configs/pulls
 

--- a/packages/prettier-config/index.js
+++ b/packages/prettier-config/index.js
@@ -4,6 +4,7 @@
 module.exports = {
   arrowParens: 'avoid',
   experimentalTernaries: true,
+  jsxSingleQuote: true,
   singleAttributePerLine: true,
   singleQuote: true,
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- [prettier-config] Add new rule to override jsxSingleQuote default behaviour.
- [prettier-config] Improve the documentation

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
No related issue

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Customize prettier-config according to my needs.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
No tests needed

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
